### PR TITLE
After-stream recording restart in case of stream error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Added recording retention parameters:
 - 'recordingsizelimit="512"': Maximum size of the recordings in total in MBs
 - 'recordingretention="3"': Recordings older than the given limit (in days) will be deleted
 
-Implement more user-friendly recording naming scheme
-Edit recording metadata to include stream title and audio language
+Implement more user-friendly recording naming scheme  
+Edit recording metadata to include stream title and audio language  
+Added after-stream double check to restart recording as soon as possible in case of a stream error
 
 ### 1.8.4
 Added support for passing additional arguments to Streamlink 

--- a/streamlink-recorder.py
+++ b/streamlink-recorder.py
@@ -215,6 +215,8 @@ def loopcheck(do_delete):
         if do_delete:
             check_recording_limits()
         record_stream(stream_data)
+        # Wait for problematic stream parts to pass
+        time.sleep(10)
         loopcheck(False)
 
     t = Timer(timer, loopcheck, [True])


### PR DESCRIPTION
# Changelog 
- Add call to restart recording if needed after a recording has stopped
- Add small switch to enable/disable recording removal in the main loop
- Update README